### PR TITLE
Add Admin Mode with Teacher Login

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,15 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+import hashlib
+import json
 import os
+import secrets
 from pathlib import Path
+from typing import Optional
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +22,24 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from JSON file
+_teachers_path = current_dir / "teachers.json"
+with open(_teachers_path) as f:
+    _teachers_data = json.load(f)
+teachers = {t["username"]: t for t in _teachers_data["teachers"]}
+
+# In-memory session token store: token -> username
+active_tokens: dict[str, str] = {}
+
+
+def _require_admin(authorization: Optional[str]):
+    """Raise 401 if the Authorization header does not carry a valid admin token."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authentication required")
+    token = authorization.removeprefix("Bearer ")
+    if token not in active_tokens:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
 
 # In-memory activity database
 activities = {
@@ -83,14 +105,40 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.post("/login")
+def login(credentials: dict):
+    """Authenticate a teacher and return a session token."""
+    username = credentials.get("username", "")
+    password = credentials.get("password", "")
+    password_hash = hashlib.sha256(password.encode()).hexdigest()
+
+    teacher = teachers.get(username)
+    if not teacher or teacher["password_hash"] != password_hash:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_hex(32)
+    active_tokens[token] = username
+    return {"token": token, "name": teacher["name"]}
+
+
+@app.post("/logout")
+def logout(authorization: Optional[str] = Header(default=None)):
+    """Invalidate the current session token."""
+    if authorization and authorization.startswith("Bearer "):
+        token = authorization.removeprefix("Bearer ")
+        active_tokens.pop(token, None)
+    return {"message": "Logged out"}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, authorization: Optional[str] = Header(default=None)):
     """Sign up a student for an activity"""
+    _require_admin(authorization)
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +159,9 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, authorization: Optional[str] = Header(default=None)):
     """Unregister a student from an activity"""
+    _require_admin(authorization)
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,92 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupContainer = document.getElementById("signup-container");
+
+  // Auth elements
+  const authBtn = document.getElementById("auth-btn");
+  const adminLabel = document.getElementById("admin-label");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginError = document.getElementById("login-error");
+  const cancelLogin = document.getElementById("cancel-login");
+
+  // Auth state
+  let adminToken = sessionStorage.getItem("adminToken") || null;
+  let adminName = sessionStorage.getItem("adminName") || null;
+
+  function updateAuthUI() {
+    if (adminToken) {
+      authBtn.textContent = "🔓";
+      authBtn.title = "Logout";
+      adminLabel.textContent = `${adminName} (Admin)`;
+      adminLabel.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+    } else {
+      authBtn.textContent = "👤";
+      authBtn.title = "Teacher Login";
+      adminLabel.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+    }
+    // Re-render activities to show/hide delete buttons
+    fetchActivities();
+  }
+
+  authBtn.addEventListener("click", async () => {
+    if (adminToken) {
+      // Logout
+      await fetch("/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${adminToken}` },
+      });
+      adminToken = null;
+      adminName = null;
+      sessionStorage.removeItem("adminToken");
+      sessionStorage.removeItem("adminName");
+      updateAuthUI();
+    } else {
+      loginModal.classList.remove("hidden");
+      document.getElementById("login-username").focus();
+    }
+  });
+
+  cancelLogin.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+    loginError.classList.add("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("login-username").value;
+    const password = document.getElementById("login-password").value;
+
+    try {
+      const response = await fetch("/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      const result = await response.json();
+
+      if (response.ok) {
+        adminToken = result.token;
+        adminName = result.name;
+        sessionStorage.setItem("adminToken", adminToken);
+        sessionStorage.setItem("adminName", adminName);
+        loginModal.classList.add("hidden");
+        loginForm.reset();
+        loginError.classList.add("hidden");
+        updateAuthUI();
+      } else {
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch {
+      loginError.textContent = "Could not connect to server.";
+      loginError.classList.remove("hidden");
+    }
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +116,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${adminToken ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
@@ -80,6 +166,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: adminToken ? { Authorization: `Bearer ${adminToken}` } : {},
         }
       );
 
@@ -124,6 +211,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: adminToken ? { Authorization: `Bearer ${adminToken}` } : {},
         }
       );
 
@@ -156,5 +244,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  updateAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -7,9 +7,35 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-username">Username:</label>
+            <input type="text" id="login-username" required placeholder="e.g. ms.johnson" />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" required />
+          </div>
+          <div id="login-error" class="hidden error-msg"></div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="cancel-login">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-area">
+        <button id="auth-btn" class="auth-btn" title="Teacher Login">👤</button>
+        <span id="admin-label" class="hidden"></span>
+      </div>
     </header>
 
     <main>
@@ -21,7 +47,7 @@
         </div>
       </section>
 
-      <section id="signup-container">
+      <section id="signup-container" class="hidden">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,11 +22,94 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
   margin-bottom: 10px;
 }
+
+#auth-area {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.auth-btn {
+  background: none;
+  border: 2px solid rgba(255,255,255,0.6);
+  border-radius: 50%;
+  color: white;
+  font-size: 20px;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  padding: 0;
+  line-height: 1;
+}
+
+.auth-btn:hover {
+  background-color: rgba(255,255,255,0.15);
+}
+
+#admin-label {
+  font-size: 13px;
+  color: rgba(255,255,255,0.85);
+  white-space: nowrap;
+}
+
+/* Login Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  padding: 30px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.modal-actions button[type="button"] {
+  background-color: #888;
+}
+
+.error-msg {
+  color: #c62828;
+  font-size: 14px;
+  margin-bottom: 10px;
+  padding: 6px 8px;
+  background: #ffebee;
+  border-radius: 4px;
+}
+
 
 main {
   display: flex;

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,14 @@
+{
+  "teachers": [
+    {
+      "username": "ms.johnson",
+      "password_hash": "cde383eee8ee7a4400adf7a15f716f179a2eb97646b37e089eb8d6d04e663416",
+      "name": "Ms. Johnson"
+    },
+    {
+      "username": "mr.smith",
+      "password_hash": "cde383eee8ee7a4400adf7a15f716f179a2eb97646b37e089eb8d6d04e663416",
+      "name": "Mr. Smith"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves #5 — Students were removing each other from activities. This PR adds an admin mode so only logged-in teachers can register/unregister students.

## Changes

### Backend (`src/app.py`)
- New `POST /login` endpoint — validates username + SHA-256 hashed password, returns a session token
- New `POST /logout` endpoint — invalidates the session token
- `POST /activities/{name}/signup` and `DELETE /activities/{name}/unregister` now require a valid `Authorization: Bearer <token>` header

### Credentials (`src/teachers.json`)
- Teacher accounts stored in a JSON file (as specified in the issue)
- Passwords stored as SHA-256 hashes, never in plaintext
- Default accounts: `ms.johnson` and `mr.smith` (default password: `teacher123`)

### Frontend
- **`index.html`**: Added a 👤 icon in the header and a login modal dialog; signup section is hidden by default
- **`app.js`**: Auth state managed via `sessionStorage`; delete buttons and signup form only visible when logged in as admin; token sent on protected API calls
- **`styles.css`**: Styles for the modal, auth icon, admin label, and error messages

## How to test
1. Open the app — the signup section and ❌ buttons are hidden
2. Click 👤 → enter `ms.johnson` / `teacher123` → login
3. Signup form and delete buttons become visible
4. Click 🔓 to logout — controls hide again